### PR TITLE
135 - Fixed search API 500 error with empty keywords 

### DIFF
--- a/server/controllers/searchController.ts
+++ b/server/controllers/searchController.ts
@@ -28,6 +28,11 @@ function getSearchRequest(req: Request, res: Response): SearchRequest {
 
     let keywords: string = sanitizeKeywords(req.body.keywords);
 
+    if (keywords === "") {
+        res.status(400).send({error: "The keywords property must include search terms."});
+        return null;
+    }
+
     let take: number = req.body.take ? req.body.take : defaultTake;
     if ((typeof take) !== "number" || take !== Math.floor(take) || take < 1) {
         res.status(400).send({error: "The take property must be a positive integer."});
@@ -103,10 +108,6 @@ function getSearchRequest(req: Request, res: Response): SearchRequest {
 }
 
 async function queryJobs(search: SearchRequest, connection: Connection): Promise<any[]> {
-    if (search.keywords === "") {
-        return [];
-    }
-
     let queryBuilder: SelectQueryBuilder<any> = await connection.createQueryBuilder();
     addSelects(search, queryBuilder);
 

--- a/server/controllers/searchController.ts
+++ b/server/controllers/searchController.ts
@@ -103,6 +103,10 @@ function getSearchRequest(req: Request, res: Response): SearchRequest {
 }
 
 async function queryJobs(search: SearchRequest, connection: Connection): Promise<any[]> {
+    if (search.keywords === "") {
+        return [];
+    }
+
     let queryBuilder: SelectQueryBuilder<any> = await connection.createQueryBuilder();
     addSelects(search, queryBuilder);
 


### PR DESCRIPTION
I just added a small check to see if the keywords were empty and if so, returned an empty array. I think this makes sense because it avoids exceptional return values (i.e. 400 response). 