### PR TITLE
Feature/116

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,28 +1,46 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router-dom';
 import './css/ResultsTable.css';
 import Navbar from './views/Navbar';
 import Footer from './views/Footer';
 import ResultData from './components/ResultData';
+import ResultsTable from './components/ResultsTable';
 import FilterMenu from './components/FilterMenu';
 import Routes from './config/Routes';
-import { withRouter } from 'react-router-dom';
 
 class App extends Component {
-
   constructor(props, context) {
     super(props, context);
 
     this.state = {
       data: [],
-      isFilterMenuVisible: false
+      isFilterMenuVisible: false,
+      latitude: 0.0,
+      longitude: 0.0,
+      categories: [],
+      industries: [],
+      salary: 0,
     };
   }
 
   toggleFilterVisibility = () => {
     this.setState(prevState => ({
-      isFilterMenuVisible: !prevState.isFilterMenuVisible
+      isFilterMenuVisible: !prevState.isFilterMenuVisible,
     }));
   };
+
+  onChangeLocation = (newLatLng) => {
+    this.setState({
+      latitude: newLatLng.lat,
+      longitude: newLatLng.lng,
+    });
+  }
+
+  onChangeMinSalary = (newSalary) => {
+    this.setState({
+      salary: newSalary,
+    });
+  }
 
   callBackendAPI = async() => {
     const response = await fetch('/express_backend');
@@ -35,16 +53,32 @@ class App extends Component {
     return body;
   };
 
+  // construct the JSON body of the search request
+  constructBody = (searchKeywords) => {
+    const body = {
+      keywords: searchKeywords,
+    };
+    if (this.state.salary) {
+      body.salaryMin = this.state.salary;
+    }
+
+    if (this.state.latitude && this.state.longitude) {
+      body.latitude = this.state.latitude;
+      body.longitude = this.state.longitude;
+      // TODO: let user choose radius
+      body.radius = 50;
+    }
+    return JSON.stringify(body);
+  }
+
   searchHandler = (searchKeywords) => async() => {
     const response = await fetch('http://localhost:5000/search', {
       method: 'POST',
-      headers:{
+      headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        'keywords': searchKeywords
-      })
+      body: this.constructBody(searchKeywords),
     });
 
     const body = await response.json();
@@ -65,13 +99,17 @@ class App extends Component {
         {this.state.isFilterMenuVisible ?
           <button id="filterButton" className="show clickable" onClick={this.toggleFilterVisibility}/> :
           <button id="filterButton" className="hide clickable" onClick={this.toggleFilterVisibility}>Filters</button>}
-        <FilterMenu visibility={this.state.isFilterMenuVisible} />
+        <FilterMenu
+          visibility={this.state.isFilterMenuVisible}
+          changeSalary={this.onChangeMinSalary}
+          changeLocation={this.onChangeLocation}
+        />
         <Routes results={this.state.data}/>
-        {/*<ResultsTable results={this.state.data} />*/}
+        <ResultsTable results={this.state.data} />
         <Footer/>
       </div>
     );
   }
 }
 
-export default withRouter(App)
+export default withRouter(App);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,8 +3,8 @@ import { withRouter } from 'react-router-dom';
 import './css/ResultsTable.css';
 import Navbar from './views/Navbar';
 import Footer from './views/Footer';
-import ResultData from './components/ResultData';
-import ResultsTable from './components/ResultsTable';
+// import ResultData from './components/ResultData';
+// import ResultsTable from './components/ResultsTable';
 import FilterMenu from './components/FilterMenu';
 import Routes from './config/Routes';
 
@@ -105,7 +105,7 @@ class App extends Component {
           changeLocation={this.onChangeLocation}
         />
         <Routes results={this.state.data}/>
-        <ResultsTable results={this.state.data} />
+        {/* <ResultsTable results={this.state.data} /> */}
         <Footer/>
       </div>
     );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,8 +3,6 @@ import { withRouter } from 'react-router-dom';
 import './css/ResultsTable.css';
 import Navbar from './views/Navbar';
 import Footer from './views/Footer';
-// import ResultData from './components/ResultData';
-// import ResultsTable from './components/ResultsTable';
 import FilterMenu from './components/FilterMenu';
 import Routes from './config/Routes';
 
@@ -105,7 +103,6 @@ class App extends Component {
           changeLocation={this.onChangeLocation}
         />
         <Routes results={this.state.data}/>
-        {/* <ResultsTable results={this.state.data} /> */}
         <Footer/>
       </div>
     );

--- a/client/src/components/FilterMenu.js
+++ b/client/src/components/FilterMenu.js
@@ -25,8 +25,18 @@ class FilterMenu extends Component {
     }));
   }
 
-  // for now, just update this.state.address and print the latlng
   handleLocationChange = address => {
+    this.setState({ address });
+
+    if (address === '') {
+      // if the address field is cleared, set latitude and longitude to 0.0
+      // so that location won't be used in the search query
+      this.props.changeLocation({ latitude: 0.0, longitude: 0.0 });
+    }
+  }
+
+  // for now, just update this.state.address and print the latlng
+  handleLocationSelect = address => {
     geocodeByAddress(address)
       .then(results => getLatLng(results[0]))
       .then(latLng => {
@@ -88,7 +98,8 @@ class FilterMenu extends Component {
           <div className="filterContent">
             <PlacesAutocomplete
               value={this.state.address}
-              onChange={this.handleLocationChange}>
+              onChange={this.handleLocationChange}
+              onSelect={this.handleLocationSelect}>
               {this.renderFunc}
             </PlacesAutocomplete>
           </div>

--- a/client/src/components/FilterMenu.js
+++ b/client/src/components/FilterMenu.js
@@ -56,7 +56,10 @@ class FilterMenu extends Component {
   }
 
   onChangeSalary = (event) => {
-    this.props.changeSalary(event.target.value);
+    const newSalary = parseInt(event.target.value, 10);
+    if ((typeof newSalary) === 'number') {
+      this.props.changeSalary(newSalary);
+    }
   }
 
   // source: https://github.com/hibiken/react-places-autocomplete

--- a/client/src/components/FilterMenu.js
+++ b/client/src/components/FilterMenu.js
@@ -1,19 +1,18 @@
-import React, { Component } from "react";
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import '.././css/FilterMenu.css';
 import PlacesAutocomplete, {
   geocodeByAddress,
   getLatLng,
 } from 'react-places-autocomplete';
+import '.././css/FilterMenu.css';
 
 class FilterMenu extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
       isMenuVisible: false,
       isShowLocation: false,
-      address: "",
+      address: '',
       isShowCategories: false,
       isShowIndustries: false,
       isShowSalary: false,
@@ -22,41 +21,42 @@ class FilterMenu extends Component {
 
   toggleLocation = () => {
     this.setState(prevState => ({
-      isShowLocation: !prevState.isShowLocation
+      isShowLocation: !prevState.isShowLocation,
     }));
   }
 
-  handleLocationChange = address => {
-    this.setState({ address });
-  }
-
   // for now, just update this.state.address and print the latlng
-  handleLocationSelect = address => {
+  handleLocationChange = address => {
     geocodeByAddress(address)
       .then(results => getLatLng(results[0]))
       .then(latLng => {
         console.log('Success', latLng);
         this.setState({ address });
+        this.props.changeLocation(latLng);
       })
       .catch(error => console.error('Error', error));
   }
 
   toggleCategories = () => {
     this.setState(prevState => ({
-      isShowCategories: !prevState.isShowCategories
+      isShowCategories: !prevState.isShowCategories,
     }));
   }
 
   toggleIndustries = () => {
     this.setState(prevState => ({
-      isShowIndustries: !prevState.isShowIndustries
+      isShowIndustries: !prevState.isShowIndustries,
     }));
   }
 
   toggleSalary = () => {
     this.setState(prevState => ({
-      isShowSalary: !prevState.isShowSalary
+      isShowSalary: !prevState.isShowSalary,
     }));
+  }
+
+  onChangeSalary = (event) => {
+    this.props.changeSalary(event.target.value);
   }
 
   // source: https://github.com/hibiken/react-places-autocomplete
@@ -75,7 +75,7 @@ class FilterMenu extends Component {
 
   render() {
     return (
-      <div id="flyoutMenu" className={this.props.visibility ? "show" : "hide"}>
+      <div id="flyoutMenu" className={this.props.visibility ? 'show' : 'hide'}>
         <h3>Filters</h3>
         <div className="locationTitle">
           <p>LOCATIONS</p>
@@ -85,8 +85,7 @@ class FilterMenu extends Component {
           <div className="filterContent">
             <PlacesAutocomplete
               value={this.state.address}
-              onChange={this.handleLocationChange}
-              onSelect={this.handleLocationSelect}>
+              onChange={this.handleLocationChange}>
               {this.renderFunc}
             </PlacesAutocomplete>
           </div>
@@ -161,7 +160,7 @@ class FilterMenu extends Component {
         </div>
         {(this.state.isShowSalary) ?
           <div className="filterContent">
-            <input type="text" name="name" placeholder="Enter minimum" />
+            <input type="text" name="name" placeholder="Enter minimum" onChange={this.onChangeSalary}/>
           </div>
           : null}
       </div>
@@ -170,7 +169,9 @@ class FilterMenu extends Component {
 }
 
 FilterMenu.propTypes = {
-  visibility: PropTypes.bool
+  visibility: PropTypes.bool,
+  changeSalary: PropTypes.func,
+  changeLocation: PropTypes.func,
 };
 
 export default FilterMenu;


### PR DESCRIPTION
With this PR, the `location` and `salary` filters are being used to build the search query. The other 2 filters are `categories` and `industries`, but they don't really map to anything in the searchRequest interface and may still change depending on new designs.

Notes
- Right now if the user doesn't put in an actual number in the salary field, the salaryMin just gets left out of the search request.
- All the latlngs in our database are 0.0, 0.0 since ZipRecruiter's data doesn't contain latlng. So if you actually input a location you won't get any results, but you can check the network log in the chrome developer tools to make sure the search request payload contains latitude, longitude and radius.